### PR TITLE
fix(script): add CI wait functionality to auto-commit workflow

### DIFF
--- a/user_script/auto_commit.sh
+++ b/user_script/auto_commit.sh
@@ -37,7 +37,8 @@ Your mission: fully automate the workflow of generating semantic branches, clean
     - PR body = summary of branch purpose and details. \
  \
 #### 5. Merge Pull Requests (Custom Merge Message) \
-- Merge PRs using **merge commit strategy**: \
+- Wait for CI ends. ('gh run watch' command streams CI logs then, exits you can use this)
+- If CI ends successfully, merge PRs using **merge commit strategy**: \
   'gh pr merge --merge --subject <custom message>' \
 - The custom merge commit message must follow this pattern: \
 Merge : \


### PR DESCRIPTION
Add CI wait functionality to auto-commit workflow

- Add 'gh run watch' command to wait for CI completion
- Ensure merge only happens after successful CI runs  
- Improve workflow reliability by preventing premature merges

This fixes the issue where PRs were being merged without waiting for CI validation, ensuring code quality and preventing broken builds.