### PR TITLE
refactor(nix): restructure nix-darwin configuration

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -68,8 +68,13 @@
       darwinConfigurations = {
         conf = nix-darwin.lib.darwinSystem {
           inherit system;
+          specialArgs = {
+            inherit user;
+            inherit arch;
+            inherit os;
+          };
           modules = [
-            ./nix-darwin/${user-system}.nix
+            ./nix-darwin
           ];
         };
       };

--- a/nix/nix-darwin/default.nix
+++ b/nix/nix-darwin/default.nix
@@ -1,7 +1,11 @@
 {
-  username,
+  user,
+  arch,
+  os,
   pkgs,
-}: {
+  ...
+}:
+{
   security = {
     pam = {
       services = {
@@ -37,8 +41,8 @@
       "slack"
       "homerow"
       # "iterm2"
-      "mouseless"
-      "docker-desktop"
+      # "mouseless"
+      # "docker-desktop"
     ];
     taps = [
       # "koekeishiya/formulae"
@@ -52,7 +56,7 @@
     enable = false;
   };
   system = {
-    primaryUser = username;
+    primaryUser = user;
     stateVersion = 6;
     defaults = {
       NSGlobalDomain = {

--- a/nix/secret.nix
+++ b/nix/secret.nix
@@ -1,7 +1,7 @@
 {}:
 {
-  user = "hiromichi.sugiura";
+  user = "a";
   arch = "aarch64";
   os ="darwin";
-  home = /Users/hiromichi.sugiura;
+  home = /Users/a;
 }


### PR DESCRIPTION
This PR restructures the nix-darwin configuration for better organization and consistency.

## Changes
- Moved nix-darwin/common/default.nix to nix-darwin/default.nix for cleaner structure
- Added specialArgs to pass user, arch, and os variables to darwin configuration  
- Updated parameter names from username to user for consistency
- Commented out unused applications (mouseless, docker-desktop)
- Updated user configuration from hiromichi.sugiura to a

## Impact
- Cleaner directory structure
- More consistent variable naming
- Better parameter passing to nix-darwin modules