### PR TITLE
feat(nvim): enable LSP inlay hints globally

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -17,6 +17,7 @@ vim.opt.cursorcolumn = true
 vim.opt.laststatus = 3
 vim.opt.termguicolors = true
 vim.diagnostic.config { virtual_text = true }
+vim.lsp.inlay_hint.enable()
 
 local lazypath = vim.fn.stdpath 'data' .. '/lazy/lazy.nvim'
 if not vim.loop.fs_stat(lazypath) then

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -1,7 +1,10 @@
 local on_attach = function(client, bufnr)
-	if client.server_capabilities.inlayHintProvider then
-		vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
-	end
+	-- if client.server_capabilities.inlayHintProvider then
+	-- 	vim.lsp.inlay_hint.enable()
+	-- 	vim.notify(vim.lsp.inlay_hint.is_enabled(), vim.log.levels.INFO, {})
+	-- else
+	-- 	vim.notify 'inlay_hint not'
+	-- end
 end
 
 return {


### PR DESCRIPTION
This PR enables LSP inlay hints globally in Neovim for improved code readability.

## Changes
- Added vim.lsp.inlay_hint.enable() to init.lua for global inlay hints
- Commented out buffer-specific inlay hint logic in lsp.lua
- Simplified inlay hint configuration for better user experience

## Impact
- Inlay hints are now enabled globally across all LSP-supported buffers
- Cleaner and more consistent inlay hint behavior
- Better development experience with type information displayed inline